### PR TITLE
SCP: future-proof save/restore logic

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -533,6 +533,7 @@ const char *sim_savename = sim_name;      /* Simulator Name used in SAVE/RESTORE
 /* Tables and strings */
 
 const char save_vercur[] = "V4.0";
+const char save_ver40[] = "V4.0";
 const char save_ver35[] = "V3.5";
 const char save_ver32[] = "V3.2";
 const char save_ver30[] = "V3.0";
@@ -5406,6 +5407,8 @@ REG *rptr;
 
 #define WRITE_I(xx) sim_fwrite (&(xx), sizeof (xx), 1, sfile)
 
+/* Don't make changes below without also changing save_vercur above */
+
 fprintf (sfile, "%s\n%s\n%s\n%s\n%s\n%.0f\n",
     save_vercur,                                        /* [V2.5] save format */
     sim_savename,                                       /* sim name */
@@ -5550,7 +5553,7 @@ t_bool force_restore = sim_switches & SWMASK ('F');
 fstat (fileno (rfile), &rstat);
 READ_S (buf);                                           /* [V2.5+] read version */
 v40 = v35 = v32 = FALSE;
-if (strcmp (buf, save_vercur) == 0)                     /* version 4.0? */
+if (strcmp (buf, save_ver40) == 0)                      /* version 4.0? */
     v40 = v35 = v32 = TRUE;
 if (strcmp (buf, save_ver35) == 0)                      /* version 3.5? */
     v35 = v32 = TRUE;


### PR DESCRIPTION
	Distinguish explicitly between save_vercur, the version that is
	used by sim_save(), and save_ver40, the latest defined version
	that is supported by sim_rest().

	The intent is to ensure that a change to save_vercur does not
	cause an unedited sim_rest() to think it knows how to read that
	new format if a human forgets to add the appropriate logic. This
	also removes some possible ambiguity in sim_rest() about what
	elements are present in what format versions.

	Finally, added a comment reminding authors to update save_vercur
	in conjunction with any changes to sim_save().